### PR TITLE
Disable modules autolink

### DIFF
--- a/FABOperation/libFABOperation.xcconfig
+++ b/FABOperation/libFABOperation.xcconfig
@@ -14,3 +14,5 @@ CODE_SIGN_IDENTITY[sdk=iphone*] =
 CODE_SIGN_IDENTITY[sdk=macosx*] =
 CODE_SIGN_IDENTITY[sdk=appletv*] =
 CODE_SIGN_IDENTITY[sdk=watch*] =
+
+CLANG_MODULES_AUTOLINK = NO


### PR DESCRIPTION
If module autolink is enabled for a static library, LC_LINKER_OPTION load commands are appended to the static library. This can cause problems when building code with newer versions of Xcode (e.g., Xcode 9) and then trying to incorporate the static libraries into projects built with older versions of Xcode (e.g., Xcode 8) because newer frameworks might not be available in the older version.